### PR TITLE
Fix the "Never suspend tabs that contain unsaved form inputs" feature

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -14,9 +14,9 @@
   let isIgnoreForms = false;
   let tempWhitelist = false;
 
-  function formInputListener(e) {
+  function formInputListener(event) {
     if (!isReceivingFormInput && !tempWhitelist) {
-      if (event.keyCode >= 48 && event.keyCode <= 90 && event.target.tagName) {
+      if (event.key >= "0" && event.key <= "z" && event.target.tagName) {
         if (
           event.target.tagName.toUpperCase() === 'INPUT' ||
           event.target.tagName.toUpperCase() === 'TEXTAREA' ||

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Unofficial The Great Suspender",
   "description": "__MSG_ext_extension_description__",
-  "version": "7.1.5",
+  "version": "7.1.5.1",
   "default_locale": "en",
   "permissions": [
     "tabs",


### PR DESCRIPTION
    There were several issues with this feature:
    * the `event` variable isn't defined
    * Firefox had unclear support for the `keyCode` property, which also
      has been deprecated for some time now.
    * The key range seemed to consider only characters from '0' to 'Z',
      excluding lower case common text for instance.

With this patch the feature works, as shown by the screenshot:
![screenshot5](https://github.com/user-attachments/assets/ba30d407-ef6b-4526-baff-99c5d0e7c528)
